### PR TITLE
feat(ynab): route transactions as transfers when identifier matches another configured account

### DIFF
--- a/src/bot/storage/ynab.test.ts
+++ b/src/bot/storage/ynab.test.ts
@@ -1,0 +1,225 @@
+import { transactionRow, config } from "../../utils/tests.js";
+import type { MoneymanConfig } from "../../config.js";
+import { TransactionStatuses } from "israeli-bank-scrapers/lib/transactions.js";
+
+const mockLog = jest.fn();
+jest.mock("../../utils/logger.js", () => ({
+  createLogger: () => mockLog,
+}));
+
+const mockGetPlanById = jest.fn();
+const mockGetAccounts = jest.fn();
+const mockCreateTransactions = jest.fn();
+
+jest.mock("ynab", () => ({
+  API: jest.fn().mockImplementation(() => ({
+    plans: { getPlanById: mockGetPlanById },
+    accounts: { getAccounts: mockGetAccounts },
+    transactions: { createTransactions: mockCreateTransactions },
+  })),
+  TransactionClearedStatus: { Cleared: "cleared" },
+}));
+
+// Import after the mocks are registered so the module under test picks up the
+// mocked SDK.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { YNABStorage } = require("./ynab.js");
+
+const mkConfig = (accounts: Record<string, string>): MoneymanConfig => {
+  const cfg = config();
+  cfg.storage = {
+    ynab: {
+      token: "test-token",
+      budgetId: "test-budget-id",
+      accounts,
+    },
+  };
+  return cfg;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPlanById.mockResolvedValue({
+    data: { plan: { name: "Test Budget" } },
+  });
+  mockGetAccounts.mockResolvedValue({
+    data: {
+      accounts: [
+        {
+          id: "ynab-hapoalim-uuid",
+          name: "Hapoalim",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "hapoalim-transfer-payee",
+        },
+        {
+          id: "ynab-cal8339-uuid",
+          name: "Cal8339",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "cal8339-transfer-payee",
+        },
+        {
+          id: "ynab-cal7299-uuid",
+          name: "Cal7299",
+          closed: false,
+          deleted: false,
+          transfer_payee_id: "cal7299-transfer-payee",
+        },
+      ],
+    },
+  });
+  mockCreateTransactions.mockResolvedValue({
+    data: { transactions: [{}], duplicate_import_ids: [] },
+  });
+});
+
+describe("YNABStorage transfer routing by identifier", () => {
+  const fullConfig = () =>
+    mkConfig({
+      "hapoalim-acct": "ynab-hapoalim-uuid",
+      "8339": "ynab-cal8339-uuid",
+      "7299": "ynab-cal7299-uuid",
+    });
+
+  it("routes a transaction as a YNAB transfer when tx.identifier matches another configured account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    expect(mockCreateTransactions).toHaveBeenCalledTimes(1);
+    const sentTxs = mockCreateTransactions.mock.calls[0][1].transactions;
+    expect(sentTxs).toHaveLength(1);
+    expect(sentTxs[0]).toMatchObject({
+      account_id: "ynab-hapoalim-uuid",
+      payee_id: "cal8339-transfer-payee",
+    });
+    // When sending as a transfer we set payee_id only — payee_name must be
+    // absent so YNAB derives the display name from the transfer target.
+    expect(sentTxs[0].payee_name).toBeUndefined();
+  });
+
+  it("sends a normal transaction (no transfer) when tx.identifier is missing", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "8339",
+      identifier: undefined,
+      description: "BIT",
+      chargedAmount: -50,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("BIT");
+  });
+
+  it("sends a normal transaction when tx.identifier matches no configured account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "9999", // not in the accounts map
+      description: "Some Merchant",
+      chargedAmount: -100,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("Some Merchant");
+  });
+
+  it("does not self-transfer when tx.identifier resolves to the same account as tx.account", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "8339",
+      identifier: "8339", // same as source
+      description: "Some Merchant",
+      chargedAmount: -75,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("Some Merchant");
+  });
+
+  it("logs a debug line when a transaction is routed as a transfer", async () => {
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const transferLogCall = mockLog.mock.calls.find(
+      (args) =>
+        typeof args[0] === "string" &&
+        args[0].includes("routing tx as transfer"),
+    );
+    expect(transferLogCall).toBeDefined();
+    expect(transferLogCall[0]).toContain("8339");
+  });
+
+  it("falls back to a normal transaction when the target account has no transfer_payee_id (e.g. closed account)", async () => {
+    // Replace the Cal8339 account with one that has no transfer_payee_id.
+    mockGetAccounts.mockResolvedValueOnce({
+      data: {
+        accounts: [
+          {
+            id: "ynab-hapoalim-uuid",
+            name: "Hapoalim",
+            closed: false,
+            deleted: false,
+            transfer_payee_id: "hapoalim-transfer-payee",
+          },
+          {
+            id: "ynab-cal8339-uuid",
+            name: "Cal8339 (closed)",
+            closed: true,
+            deleted: false,
+            transfer_payee_id: null,
+          },
+        ],
+      },
+    });
+
+    const storage = new YNABStorage(fullConfig());
+
+    const tx = transactionRow({
+      account: "hapoalim-acct",
+      identifier: "8339",
+      description: "כאל",
+      chargedAmount: -19198.74,
+      status: TransactionStatuses.Completed,
+    });
+
+    await storage.saveTransactions([tx], async () => {});
+
+    const sentTx = mockCreateTransactions.mock.calls[0][1].transactions[0];
+    expect(sentTx.payee_id).toBeUndefined();
+    expect(sentTx.payee_name).toBe("כאל");
+  });
+});

--- a/src/bot/storage/ynab.ts
+++ b/src/bot/storage/ynab.ts
@@ -16,6 +16,7 @@ export class YNABStorage implements TransactionStorage {
   private ynabAPI: ynab.API;
   private budgetName = "";
   private accountToYnabAccount = new Map<string, string>();
+  private ynabAccountToTransferPayeeId = new Map<string, string>();
 
   constructor(private config: MoneymanConfig) {}
 
@@ -27,6 +28,12 @@ export class YNABStorage implements TransactionStorage {
     this.ynabAPI = new ynab.API(ynabConfig.token);
     this.budgetName = await this.getBudgetName(ynabConfig.budgetId);
     this.accountToYnabAccount = new Map(Object.entries(ynabConfig.accounts));
+    this.ynabAccountToTransferPayeeId = await this.fetchTransferPayeeIds(
+      ynabConfig.budgetId,
+    );
+    logger(
+      `loaded ${this.ynabAccountToTransferPayeeId.size} transfer payee mappings`,
+    );
   }
 
   canSave() {
@@ -115,18 +122,63 @@ export class YNABStorage implements TransactionStorage {
     }
   }
 
+  private async fetchTransferPayeeIds(
+    budgetId: string,
+  ): Promise<Map<string, string>> {
+    const accountsResponse = await this.ynabAPI.accounts.getAccounts(budgetId);
+    if (!accountsResponse.data) {
+      throw new Error(`Failed to fetch accounts for budget: ${budgetId}`);
+    }
+    const map = new Map<string, string>();
+    for (const account of accountsResponse.data.accounts) {
+      if (!account.deleted && !account.closed && account.transfer_payee_id) {
+        map.set(account.id, account.transfer_payee_id);
+      }
+    }
+    return map;
+  }
+
+  // When a scraped transaction's identifier matches the key of a *different*
+  // configured account, treat the transaction as a transfer to that account.
+  // This covers cases where the bank's activityDescription doesn't distinguish
+  // between cards (e.g. Bank Hapoalim returns the bare "כאל" for every Visa-Cal
+  // debit, with the actual card last-4 surfaced only in the reference number
+  // field — which israeli-bank-scrapers exposes as tx.identifier).
+  private resolveTransferPayeeId(
+    tx: TransactionRow,
+    sourceAccountId: string,
+  ): string | undefined {
+    const identifier = tx.identifier?.toString();
+    if (!identifier) return undefined;
+
+    const targetAccountId = this.accountToYnabAccount.get(identifier);
+    if (!targetAccountId || targetAccountId === sourceAccountId) {
+      return undefined;
+    }
+
+    const transferPayeeId =
+      this.ynabAccountToTransferPayeeId.get(targetAccountId);
+    if (transferPayeeId) {
+      logger(
+        `routing tx as transfer: source=${sourceAccountId} identifier=${identifier} -> target=${targetAccountId}`,
+      );
+    }
+    return transferPayeeId;
+  }
+
   private convertTransactionToYnabFormat(
     tx: TransactionRow,
     accountId: string,
   ): ynab.SaveTransactionWithIdOrImportId {
     const amount = Math.round(tx.chargedAmount * 1000);
+    const transferPayeeId = this.resolveTransferPayeeId(tx, accountId);
 
     return {
       account_id: accountId,
       date: format(parseISO(tx.date), YNAB_DATE_FORMAT, {}),
       amount,
-      payee_id: undefined,
-      payee_name: tx.description,
+      payee_id: transferPayeeId,
+      payee_name: transferPayeeId ? undefined : tx.description,
       cleared:
         tx.status === TransactionStatuses.Completed
           ? ynab.TransactionClearedStatus.Cleared


### PR DESCRIPTION
When the bank's activityDescription is ambiguous between multiple cards on the same billing account (e.g. Bank Hapoalim returns the bare "כאל" for every Visa-Cal monthly debit, with the real card last-4 surfaced only in the reference-number field that israeli-bank-scrapers exposes as `tx.identifier`), the existing exporter sent all such debits with the same payee_name. YNAB's renaming rules then collapse them all to a single Transfer payee, so multi-card households see one card "swallowing" the other's monthly payments and drift out of sync over time.

This change introduces identifier-based transfer routing. In init() we fetch the YNAB account list once and build a map of ynabAccountId -> transfer_payee_id. Before serializing each transaction, we check whether tx.identifier matches a different key in the existing ynab.accounts config; if it does, the transaction is sent as a YNAB transfer (payee_id set to the target's transfer_payee_id, no payee_name) so YNAB creates the correct paired entry.

The mapping is config-driven via the existing ynab.accounts object — no new configuration. Defensive fallbacks preserve existing behavior when the identifier is missing, doesn't match any account, resolves to the same account, or the target lacks a transfer_payee_id.

Adds src/bot/storage/ynab.test.ts (previously no tests for ynab storage) with coverage for all five branches.